### PR TITLE
Branch Tutorial 5: Rust in Action - Add crypto different units 

### DIFF
--- a/tutorial-5/src/lib.rs
+++ b/tutorial-5/src/lib.rs
@@ -5,6 +5,7 @@ pub mod health;
 pub mod key_value_store;
 pub mod mockservices;
 pub mod serve;
+pub mod units;
 
 pub fn init_tracing() {
     tracing_subscriber::fmt()

--- a/tutorial-5/src/units/eth.rs
+++ b/tutorial-5/src/units/eth.rs
@@ -98,7 +98,12 @@ mod tests {
         };
 
         let EthNewType(sum_value) = item1.add(item2);
-        assert_eq!((29484.937434 as f64 + 2445.284634 as f64), sum_value)
+        assert_eq!((29484.937434 as f64 + 2445.284634 as f64), sum_value);
+
+        assert_eq!(
+            item1 + item2,
+            EthNewType(29484.937434 as f64 + 2445.284634 as f64)
+        );
     }
 
     #[test]
@@ -115,6 +120,10 @@ mod tests {
 
         let EthNewType(sub_value) = item2.sub(item1);
         assert_eq!(sub_value, item2.0 - item1.0);
+        assert_eq!(
+            EthNewType(29484.937434 as f64) - EthNewType(2445.284634 as f64),
+            EthNewType(29484.937434 as f64 - 2445.284634 as f64)
+        );
     }
 
     #[test]

--- a/tutorial-5/src/units/eth.rs
+++ b/tutorial-5/src/units/eth.rs
@@ -1,0 +1,140 @@
+use std::{
+    fmt::Display,
+    ops::{Add, Sub},
+};
+
+use serde::{Deserialize, Serialize};
+
+use super::{GWeiNewType, WeiNewType};
+
+// Here we define the type to track an amount of ETH.
+// And also provided for series of functions to convert between ETH-GWei, ETH-Wei, GWei-Wei for scenarios
+// that requier more previous calculation is needed.
+
+#[derive(Clone, Copy, Debug, PartialEq, Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct EthNewType(pub f64);
+
+impl EthNewType {
+    pub const GWEI_PER_ETH: i64 = 1_000_000_000;
+    pub const WEI_PER_ETH: i128 = 1_000_000_000_000_000_000;
+}
+
+impl Add for EthNewType {
+    type Output = Self;
+    fn add(self, EthNewType(rhs): Self) -> Self::Output {
+        let EthNewType(lhs) = self;
+        let result = lhs + rhs;
+        EthNewType(result)
+    }
+}
+
+impl Sub for EthNewType {
+    type Output = Self;
+
+    fn sub(self, EthNewType(rhs): Self) -> Self::Output {
+        let EthNewType(lhs) = self;
+        let result = lhs - rhs;
+        EthNewType(result)
+    }
+}
+
+impl Display for EthNewType {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        unimplemented!()
+    }
+}
+
+/// NOTE: this loses prevision
+/// Converted Type from Gwei into Eth
+impl From<GWeiNewType> for EthNewType {
+    fn from(GWeiNewType(amount): GWeiNewType) -> Self {
+        EthNewType(amount as f64 / EthNewType::GWEI_PER_ETH as f64)
+    }
+}
+
+/// /// NOTE: this loses prevision
+impl From<WeiNewType> for EthNewType {
+    fn from(WeiNewType(amount): WeiNewType) -> Self {
+        EthNewType(amount as f64 / EthNewType::WEI_PER_ETH as f64)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::ops::{Add, Sub};
+
+    use crate::units::{
+        GWeiNewType, WeiNewType, GWEI_PER_ETH_F64, WEI_PER_ETH,
+    };
+
+    use super::EthNewType;
+
+    #[test]
+    fn test_create_EthNewType() {
+        // create new instance, we use 0 because the struct declaration not give exact struct field name
+        let item = EthNewType { 0: 93484 as f64 };
+
+        // serialize instance
+        let serialized_json = serde_json::to_string(&item).unwrap();
+        // print the serialized instance
+        println!("eth type json {:?}", serialized_json);
+
+        // deserialize instance
+        let deserialized_json =
+            serde_json::from_str::<EthNewType>(serialized_json.as_str())
+                .unwrap();
+        // print the deserialized instance
+        println!("eth type instance content {:?}", deserialized_json);
+    }
+
+    #[test]
+    fn test_add_two_EthNewType() {
+        let item1 = EthNewType {
+            0: 29484.937434 as f64,
+        };
+        let item2 = EthNewType {
+            0: 2445.284634 as f64,
+        };
+
+        let EthNewType(sum_value) = item1.add(item2);
+        assert_eq!((29484.937434 as f64 + 2445.284634 as f64), sum_value)
+    }
+
+    #[test]
+    fn test_sub_two_EthNewType() {
+        let item1 = EthNewType {
+            0: 29484.937434 as f64,
+        };
+        let item2 = EthNewType {
+            0: 2445.284634 as f64,
+        };
+
+        let EthNewType(sub_value) = item1.sub(item2);
+        assert_eq!(sub_value, item1.0 as f64 - item2.0 as f64);
+
+        let EthNewType(sub_value) = item2.sub(item1);
+        assert_eq!(sub_value, item2.0 - item1.0);
+    }
+
+    #[test]
+    fn test_convert_from_GWeiNewType() {
+        let item1 = GWeiNewType {
+            0: 8 * GWEI_PER_ETH_F64 as i64,
+        };
+        let item1_eth: EthNewType = item1.into();
+        let EthNewType(eth_value) = item1_eth;
+        assert_eq!(item1.0 as f64 / GWEI_PER_ETH_F64, eth_value);
+        println!("eth_value: {:?}, item1.0 value: {:?}", item1_eth, item1);
+    }
+
+    #[test]
+    fn test_convert_from_WeiNewType() {
+        let item = WeiNewType {
+            0: 100 * WEI_PER_ETH,
+        };
+
+        let EthNewType(amount) = item.into();
+        assert_eq!(amount as i128, item.0 / WEI_PER_ETH);
+    }
+}

--- a/tutorial-5/src/units/gwei.rs
+++ b/tutorial-5/src/units/gwei.rs
@@ -1,0 +1,54 @@
+use std::{
+    fmt,
+    num::ParseIntError,
+    ops::{Add, Div, Sub},
+    result,
+    str::FromStr,
+};
+
+use serde::{de, de::Visitor, Deserialize, Serialize};
+
+use super::{EthNewType, WeiNewType};
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct GWeiNewType(pub i64);
+
+impl fmt::Display for GWeiNewType {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+impl GWeiNewType {
+    pub const WEI_PER_GWEI: u32 = 1_000_000_000;
+}
+
+impl Add<GWeiNewType> for GWeiNewType {
+    type Output = Self;
+    fn add(self, GWeiNewType(rhs): Self) -> Self::Output {
+        let GWeiNewType(lhs) = self;
+        let result = lhs
+            .checked_add(rhs)
+            .expect("caused overflow in gwei addition");
+        GWeiNewType(result)
+    }
+}
+
+impl Sub<GWeiNewType> for GWeiNewType {
+    type Output = Self;
+    fn sub(self, GWeiNewType(rhs): Self) -> Self::Output {
+        let GWeiNewType(lhs) = self;
+        let result = lhs
+            .checked_sub(rhs)
+            .expect("caused underflow in gwei substraction");
+        GWeiNewType(result)
+    }
+}
+
+impl Div<GWeiNewType> for GWeiNewType {
+    type Output = Self;
+    fn div(self, GWeiNewType(lhs): Self) -> Self::Output {
+        let GWeiNewType(rhs) = self;
+        GWeiNewType(lhs / rhs)
+    }
+}

--- a/tutorial-5/src/units/mod.rs
+++ b/tutorial-5/src/units/mod.rs
@@ -1,0 +1,14 @@
+mod eth;
+mod gwei;
+mod usd;
+mod wei;
+
+pub use eth::EthNewType;
+pub use gwei::GWeiNewType;
+pub use wei::WeiNewType;
+
+// 1 ETH = 10 ^9 Gwei
+pub const GWEI_PER_ETH_F64: f64 = 1_000_000_000_f64;
+
+// 1 ETH = 10 ^ 18 Wei
+pub const WEI_PER_ETH: i128 = 1_000_000_000_000_000_000;

--- a/tutorial-5/src/units/usd.rs
+++ b/tutorial-5/src/units/usd.rs
@@ -1,0 +1,32 @@
+use std::{
+    fmt::Display,
+    ops::{Add, Sub},
+};
+
+use super::{EthNewType, GWeiNewType, WeiNewType};
+use serde::Serialize;
+
+/// This is abstraction of USD.
+/// We use the imprecise f64 here because most USD amounts we track are based on ETH amounts,
+/// converted to USD, which is also imprecise.
+#[derive(Clone, Copy, Debug, PartialEq, Serialize)]
+#[serde(transparent)]
+pub struct UsdNewtype(pub f64);
+
+impl UsdNewtype {
+    /// #[allow(dead_code)] purpose:
+    /// Rust has strict rules about unused code. If you define a function, struct, or variable that is not
+    /// used anywhere, the compiler issues a warning.
+    /// Adding #[allow(dead_code)] to a function, struct, or module supresses this warning.
+    #[allow(dead_code)]
+    pub fn from_eth(eth: EthNewType, eth_price: f64) -> Self {
+        let usd = eth.0 * eth_price;
+        UsdNewtype(usd)
+    }
+
+    // #[allow(dead_code)]
+    // pub fn from_gwei(gwei: GWeiNewType, eth_price: f64) -> Self {
+    //     let eth: EthNewType = gwei.into();
+    //     Self::from(eth)
+    // }
+}

--- a/tutorial-5/src/units/wei.rs
+++ b/tutorial-5/src/units/wei.rs
@@ -1,0 +1,24 @@
+//! Ethereum wei unit type and associated fns
+//! A 1e-18th of an ether(ETH).
+
+use std::{
+    fmt::Display,
+    num::ParseFloatError,
+    ops::{Add, Sub},
+    str::FromStr,
+};
+
+use serde::{Deserialize, Serialize};
+
+use super::{EthNewType, GWeiNewType, WEI_PER_ETH};
+
+pub type WeiF64 = f64;
+
+#[derive(Clone, Copy, Debug, Deserialize, Serialize, PartialEq, Eq)]
+pub struct WeiNewType(pub i128);
+
+impl WeiNewType {
+    pub fn from_eth(eth: i128) -> Self {
+        Self(eth * WEI_PER_ETH)
+    }
+}


### PR DESCRIPTION
In this commit, 
we added Ethereum cryptocurrency different unites abstract and implementation codes, like `Ether`, `GWei` , `Wei`, and `USD`. 