### PR TITLE
b_t5-store: Implement Service Layer Using PostgreSQL Database Encapsulation Class

### DIFF
--- a/tutorial-5/.gitignore
+++ b/tutorial-5/.gitignore
@@ -6,5 +6,4 @@ Cargo.lock
 **/src/Cargo.lock
 /store 
 **/bin/store/
-migrations
 .sqlx

--- a/tutorial-5/Cargo.toml
+++ b/tutorial-5/Cargo.toml
@@ -33,3 +33,4 @@ thiserror = "1.0.49"
 hyper = { version = "0.14", features = ["full"] }
 backoff = { version = "0.4.0", features = ["tokio"] }
 format-url = "0.6.2"
+serial_test = "1.0"

--- a/tutorial-5/migrations/20241217112711_add_eth_prices_table.sql
+++ b/tutorial-5/migrations/20241217112711_add_eth_prices_table.sql
@@ -1,0 +1,5 @@
+-- Add migration script here
+CREATE TABLE IF NOT EXISTS eth_prices (
+    timestamp timestamptz PRIMARY KEY,
+    ethusd float8 NOT NULL
+)

--- a/tutorial-5/src/bybit/mod.rs
+++ b/tutorial-5/src/bybit/mod.rs
@@ -12,17 +12,16 @@ use chrono::{DateTime, Duration, Utc};
 use serde::Deserialize;
 use serde::Serialize;
 use sqlx::{FromRow, PgPool};
-use std::clone;
 use tokio::time::sleep;
 use tracing::{debug, info};
 
 #[derive(Debug, FromRow)]
-struct EthPriceTimestamp {
+pub struct EthPriceTimestamp {
     timestamp: DateTime<Utc>,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize, FromRow, PartialEq)]
-struct EthPrice {
+pub struct EthPrice {
     pub timestamp: DateTime<Utc>,
     #[sqlx(rename = "ethusd")]
     pub usd: f64,

--- a/tutorial-5/src/docs/11-note-rust-bin-entry.md
+++ b/tutorial-5/src/docs/11-note-rust-bin-entry.md
@@ -13,7 +13,7 @@ By default, Rust looks for binarys under src/main.rs file. However, if we need *
 **Cargo.toml Declaration:**
 Rust allows us to declare binaries explicitly in the `Cargo.toml`. However, files placed under the `bin/` directory are automatically detected without needing manual declaration.
 
---
+---
 
 ## Sequential Entry Points
 
@@ -145,7 +145,7 @@ async fn main() {
 }
 ```
 
---
+---
 
 ## How to Run the Project
 

--- a/tutorial-5/src/docs/11-note-rust-bin-entry.md
+++ b/tutorial-5/src/docs/11-note-rust-bin-entry.md
@@ -2,19 +2,16 @@
 
 Rust projects allow us to declare multiple binary entry points for a single crate. This enables modular design where different binaries can perform separate tasks or be executed in sequence.
 
-## Understand
+## Understand Main Entry Points
 
-- `main` function:
+**`main` function:**
+This is the default entry point for any Rust binary. The main function serves as the execution start point of your application. Any initialization of **configuration**, **database migraiton**, or **pre-required services** should happen here.
 
-* This is the default entry point for any Rust binary.
-* The main function serves as the execution start point of your application.
-* Any initialization of **configuration**, **database migraiton**, or **pre-required services** should happen here.
+**Multiple Binaries (`bin/folder`):**
+By default, Rust looks for binarys under src/main.rs file. However, if we need **multiple entry points**, we can define them under the `bin/` this directory. Each file under `bin/` acts as an **independent binary**, with its own `main` function.
 
-- Multiple Binaries (`bin/folder`):
-  By default, Rust looks for binarys under src/main.rs file. However, if we need **multiple entry points**, we can define them under the `bin/` this directory. Each file under `bin/` acts as an **independent binary**, with its own `main` function.
-
-- Cargo.toml Declaration:
-  Rust allows us to declare binaries explicitly in the `Cargo.toml`. However, files placed under the `bin/` directory are automatically detected without needing manual declaration.
+**Cargo.toml Declaration:**
+Rust allows us to declare binaries explicitly in the `Cargo.toml`. However, files placed under the `bin/` directory are automatically detected without needing manual declaration.
 
 --
 
@@ -25,11 +22,10 @@ In projects where we need to run **different binaries in sequence**, you can des
 Here is an example:
 
 - First, we use a **primary entry point**(e.g., src/main.rs) to handle setup(e.g., **database initialization**, **database migration**, **config loading**, etc).
-- ## After everything setup and get ready, continue **call other binaries** which each main entry point is located under folder `bin/` to perform specific task(sync data, scheduler, long-running monitoring).
+
+- After everything setup and get ready, continue **call other binaries** which each main entry point is located under folder `bin/` to perform specific task(sync data, scheduler, long-running monitoring).
 
 ## Code Example
-
-- Project Structure
 
 ```shell
 my_project/

--- a/tutorial-5/src/docs/11-note-rust-bin-entry.md
+++ b/tutorial-5/src/docs/11-note-rust-bin-entry.md
@@ -1,0 +1,181 @@
+# Rust's Binary Entry Point System
+
+Rust projects allow us to declare multiple binary entry points for a single crate. This enables modular design where different binaries can perform separate tasks or be executed in sequence.
+
+## Understand
+
+- `main` function:
+
+* This is the default entry point for any Rust binary.
+* The main function serves as the execution start point of your application.
+* Any initialization of **configuration**, **database migraiton**, or **pre-required services** should happen here.
+
+- Multiple Binaries (`bin/folder`):
+  By default, Rust looks for binarys under src/main.rs file. However, if we need **multiple entry points**, we can define them under the `bin/` this directory. Each file under `bin/` acts as an **independent binary**, with its own `main` function.
+
+- Cargo.toml Declaration:
+  Rust allows us to declare binaries explicitly in the `Cargo.toml`. However, files placed under the `bin/` directory are automatically detected without needing manual declaration.
+
+--
+
+## Sequential Entry Points
+
+In projects where we need to run **different binaries in sequence**, you can design the primary **main** function(or an orchestrator binary) to execute them binaries one by one.
+
+Here is an example:
+
+- First, we use a **primary entry point**(e.g., src/main.rs) to handle setup(e.g., **database initialization**, **database migration**, **config loading**, etc).
+- ## After everything setup and get ready, continue **call other binaries** which each main entry point is located under folder `bin/` to perform specific task(sync data, scheduler, long-running monitoring).
+
+## Code Example
+
+- Project Structure
+
+```shell
+my_project/
+├── Cargo.toml
+├── src/
+│   └── main.rs          # Default entry point
+└── bin/
+    ├── task-one.rs      # Private binary entry point 1
+    └── task-two.rs      # Private binary entry point 2
+```
+
+#### Cargo toml
+
+```toml
+[package]
+name = "your_project_name"
+version = "0.1.0"
+edition = "2021"
+
+[[bin]]
+name = "server"
+path = "src/bin/server.rs"
+
+[dependencies]
+tokio = { version = "1", features = ["full"] }
+sqlx = { version = "0.6", features = ["runtime-tokio", "postgres"] }
+serde = { version = "1", features = ["derive"] }
+```
+
+#### Primary Entry Point (src/main.rs)
+
+The main function initializes all required dependencies (DB, configs, etc.) and then triggers private binaries.
+
+```rust
+use std::process::Command;
+
+async fn main() {
+    println!("Starting main setup ...");
+
+    // step 1: initialize databases, do migrations and configuration
+    initialize_database();
+    db_migraiton();
+
+    println!("Setup complete. Begin to execute private entry points ...");
+
+    loop {
+        // setup server
+        // listen on port 3000
+        // match request {
+        //   client_query_db_data : {
+        //       fetch_data_from_db <-- this db table's data are fetched and stored by task-one
+        //  }
+        //   client_query_streaming_system_data: {
+        //       fetch_data_from_streaming_event_sys: <--- this streaming events are monitored and broadcasted by task-two
+        // }
+        // ...
+        // }
+    }
+
+    println!("All tasks completed successfully.");
+}
+
+fn initialize_database() {
+    // ...
+}
+
+fn db_migration() {
+    // ...
+}
+
+fn load_configuration() {
+    // ...
+}
+```
+
+#### Private Entry Point 1 (bin/task_one.rs)
+
+This binary entry point is **Task1** logic, such as fetching data from remote **API Endpoints** and sync to database tables.
+
+```rust
+// bin/task-one.rs
+async fn main() {
+    // first, task-one need to loaded all database tables data
+    //        --> all database tables are already migrated in the --> server.rs's main etnry point
+    // then, task-one begins to fetch data && conver data model && sync to database tables
+
+    loop {
+        // all mocked codes...
+        let dataset = fetch_data(url).filter().map().iter().collect();
+        db_handler.save(db_config, "table-1", dataset).await?;
+        sleep(1000ms);
+    }
+}
+```
+
+#### Private Entry Point 2 (bin/task_two.rs)
+
+This binary entry point is **Task2** logic, such as register && monitoring remote listener specified event and broadcast the events to system streaming system.
+
+```rust
+// bin/task-two.rs
+async fn main() {
+    // first, task-two need to query latest data value from datbase table
+    // ---> all datasets and status are migrated via migrated files by the primary
+    //      server.rs's main() function since it is the first setup process
+    // then, task-two begin setup service that listens to remote event and subscribe specified for example transaction events
+    // and then broadcast the event to flink system as a streaming tasks (just for example...)
+
+    loop {
+        // listen to remote event system
+        // trigger event
+        // convet event to system inner-defined data structure
+        // sync to event database
+        // send/broadcast event to streaming system which is subscribed by other services
+        flink.submit("streaming-task", dataset);
+    }
+}
+```
+
+--
+
+## How to Run the Project
+
+### Run the Primary Entry Point:
+
+```shell
+# build and run the server binary
+# server's fn main() will get everything ready: {update database tables schemas, and load the initial datasets to datbase tables, and even load all environment varriables to local env config instance which gonna be shared among other entry point functions.}
+cargo build --release --bin server
+```
+
+### Run Individual Tasks
+
+Even though we haven't declare the bin entry point for task-one and task-two's main function.
+Their entry point names are their bin/{file-name}.rs filename
+
+```shell
+cargo build --release --bin task-one
+cargo build --release --bin task-two
+```
+
+---
+
+## Benefits of Organizing Project Like This
+
+- **Separation of Concerns**: Each binary focuses on a single responsibility.
+- **Isolation**: Async runtimes and resources are independently in each binary.
+- **Scalability**: Individual binarys can be built, tested, and deployed independently.
+- **Parallel Execution**: Multiple binaries can run concurrently, benefiting multi-threaded systems.

--- a/tutorial-5/src/docs/12-note-chains.md
+++ b/tutorial-5/src/docs/12-note-chains.md
@@ -1,1 +1,79 @@
-# Under Execution Chains and Beacon Chains
+# Under Execution Chain and Beacon Chain
+
+## Execution Chain (Ethereum 1.0 / Legacy Chain)
+
+The **Execution Chain** referes to the **Ethereum 1.0 chain** where transactions, smart contracts, and state data were processed. This chain handles the **execution layer** of Ethereum:
+
+- Processes **user transactions**
+- Executes **smart contracts**
+- Manages the **Ethereum Virtual Machine (EVM)**
+- Calculates **balances**, **gas fees**, and **execution states**
+
+It existed **before the Merge** and continued to run alongside the **Beacon Chain** as the **main chain**.
+
+In the **post-Merge Ethereum**, the Execution Chain still processes transactions and interacts with the EVM with the EVM but delegates consensus duties to the Beacon Chain.
+
+### Key Components of Execution Chain
+
+- Transactions
+- State update (balances, contract storage, etc.)
+- Blocks (executing EVM-based operations)
+- Gas fees and rewards (handled within the execution environment)
+
+---
+
+## Beacon Chain (Ethereum 2.0 / Consensus Chain)
+
+The **Beacon Chain** is a parallel chain introduced as part of **Ethereum 2.0**. Its role is to manage **consensus** using **Proof-of-Stake(PoS)** mechanism. The Beacon Chain became the backbone of Ethereum's consensus layer after the **Merge**. It coordinates the network of validators, handles staking, and ensures that blocks are agreed upon in a secure, decentralized manner.
+
+### Key Components of Beacon Chain
+
+- Consensus mechanism (Proof-of-Stake).
+- Validator coordination (staking, attestation, and block proposals).
+- Rewards and penalties for validators.
+- No execution of transactions or smart contracts-it's strictly about achieving consensus.
+
+---
+
+## Understand Consesus
+
+**Consensus** in blockchain refers to the process through which participants in a distributed network agree on the state of the blockchian. It ensures that all nodes (computers in the network) have a unified view of the ledger without relying on a central authority.
+
+There are two major consensus mechanisms in Ethereum's history:
+
+### **Proof-of-Work (PoW)**(this is used before **The Merge**):
+
+- **How it works**: Miners compete to solve complex cryptographic puzzles, and the first to solve it validates the block.
+- **Purpose**: Ensures security and decentralization but consumes a lot of energy.
+
+### **Proof-of-Stake (PoS)**(introduced with Beacon Chain):
+
+- **How it works**: Validators are chosen to propose and attest to new blocks based on the amount of ETH they have staked.
+- **Purpose**: Achieves consensus with less energy consumption and faster finality while incentivizing honest participation through rewards and penalties.
+
+---
+
+## The Merge
+
+After **The Merge(September 15, 2022)**, the **Beacon Chain** and **Execution Chain** combined to form a single Ethereum blockchain:
+
+- **Execution Chain** continues to process transactions and smart contracts(execution layer).
+- **Beacon Chain** ensures consensus with the **Proof-of-Stake** protocol (consensus layer).
+
+## Summary of Execution Chain vs. Beacon Chain
+
+### Key Differences
+
+- **Execution Chain**
+  Handles Ethereum Virtual Machine(EVM) execution, including transactions, smart contracts,a nd state updates. Previously relied on **Proof-of-Work** for consensus before **The Merge**.
+
+- **Beacon Chain**
+  Responsible for **Proof-of-Stake** consensus, coordinating validators, and ensuring block finality. It does not process transactions but manages attestations(votes) and validator rewards or penalties.
+
+| **Aspect**              | **Execution Chain**                       | **Beacon Chain**                          |
+| ----------------------- | ----------------------------------------- | ----------------------------------------- |
+| **Role**                | Executes transactions and smart contracts | Handles consensus via Proof-of-Stake      |
+| **Consensus Mechanism** | Proof-of-Work (before Merge)              | Proof-of-Stake                            |
+| **Focus**               | EVM, state updates, gas fees              | Validator coordination, rewards, slashing |
+| **State**               | Manages account balances, storage, etc.   | Manages validator states                  |
+| **Blocks**              | Contains transaction data                 | Contains attestations and proposals       |

--- a/tutorial-5/src/docs/12-note-chains.md
+++ b/tutorial-5/src/docs/12-note-chains.md
@@ -1,0 +1,1 @@
+# Under Execution Chains and Beacon Chains

--- a/tutorial-5/src/docs/12-note-chains.md
+++ b/tutorial-5/src/docs/12-note-chains.md
@@ -1,4 +1,4 @@
-# Under Execution Chain and Beacon Chain
+# Understand Execution Chain and Beacon Chain
 
 ## Execution Chain (Ethereum 1.0 / Legacy Chain)
 

--- a/tutorial-5/src/docs/13-note-issuance.md
+++ b/tutorial-5/src/docs/13-note-issuance.md
@@ -1,0 +1,64 @@
+# Understand Issuance in Beacon Chain
+
+In the context of Ethereum's **Beacon Chain**, **issuance** refers to the **creation of new ETH** as rewards for validators in the **Proof-of-Stake(PoS)** consensus mechanism.
+
+## What is Issuance ?
+
+- **Issuance** is the process of mining new ETH as a reward for network participants.
+- In Ethereum's **Proof-of-Stake** system (the Beacon Chain), validators are incentivized to propose and attest to blocks correctly. These incentives are paid out as **newly issued ETH**, which increases the total supply of ETH over time.
+- This is similar to how miners were rewarded in **Proof-of-Work(PoW)** pre-Merge, but in **PoS**, the rewards go to validators instead of miners.
+
+---
+
+## Why Does the Beacon Chain Issue ETH ?
+
+The issuance mechanism serves the follow purposes:
+
+### Incentivize Validators
+
+- Validators must stake **32 ETH** to participate in block validation.
+- Issuance (rewards) encourages validators to maintain the network's security, propose new blocks, and attest to the blocks propsed by others.
+
+### Secure the Network
+
+- Validators earn rewards for behaving honestly (proposing/attesting to valid blocks).
+- Misbehavior, like being offline or submitting malicious attestations, results in penalties or slashing.
+
+### Sustain Network Operations
+
+- ETH issuance ensures validators are eonomically incentivized to participate over the long term.
+
+---
+
+## How Issuance Works on the Beacon Chain?
+
+#### **ETH Rewards** are issued to validators based on their **performance**:
+
+- Proposing a block
+- Attesting to other blocks
+- Participant in sync committees(helping the chain's finality).
+
+#### Validators earn both **base rewards** and **additional rewards** for correctly contributing to consensus
+
+#### Source of Issurance
+
+- New ETH created at the protocol level as validator rewards.
+- This issuance increases the total ETH supply, but with **burn mechanisms** (like EIP-1559 on the execution layer), issuance can be offest by burned ETH.
+
+---
+
+## Issuance Rates on the Beacon Chain
+
+---
+
+## Issuance vs. Burn (Net Issuance)
+
+---
+
+## Key Takeaways
+
+---
+
+## Rea-Life Example
+
+---

--- a/tutorial-5/src/eth_prices/mod.rs
+++ b/tutorial-5/src/eth_prices/mod.rs
@@ -1,0 +1,1 @@
+mod store;

--- a/tutorial-5/src/eth_prices/store.rs
+++ b/tutorial-5/src/eth_prices/store.rs
@@ -1,0 +1,241 @@
+use crate::bybit::EthPrice;
+use crate::units::UsdNewtype;
+use async_trait::async_trait;
+use chrono::{DateTime, Duration, DurationRound, Utc};
+use sqlx::PgPool;
+use thiserror::Error;
+
+// This Postgres Store isolates operations on the `eth_prices` database table from the service layer.
+// It defines a series of operations specific to the `eth_prices` table.
+pub struct EthPriceStorePostgres {
+    db_pool: PgPool,
+}
+
+impl EthPriceStorePostgres {
+    pub fn new(db_pool: PgPool) -> Self {
+        Self { db_pool }
+    }
+}
+
+#[derive(Debug, Error, PartialEq, Eq)]
+pub enum GetEthPriceError {
+    #[error("closest price to given block was too old")]
+    PriceTooOld,
+}
+
+// From a Java developer's perspective, this is similar to:
+// - Declaring a service layer interface, e.g., `Service`, where we define a set of actions(functions).
+// - Creating a `ServiceImpl` to implement the interface(trait) and provide specific logic for each functin.
+
+// The reason we abstract a series of `eth_prices` table operations inside `EthPriceStore`
+// is to maintain compatibility with multiple data sources, such as MySQL, Redis, GraphSQL, etc.
+// This approach ensures that data source implementation details do not interfere with the business logic layer.
+
+#[async_trait]
+pub trait EthPriceStore {
+    async fn average_from_time_range(
+        &self,
+        start_timestamp: DateTime<Utc>,
+        end_timestamp: DateTime<Utc>,
+    ) -> UsdNewtype;
+
+    // this is rely on block series of functions which haven't implemented yet
+    // all block node associated ether price query in this file
+    // are based on block's timestamp value
+    // add a todo!() here
+    async fn average_from_block_plus_time_range(
+        &self,
+        // todo!() block: &ExecutionNodeBlock,
+        // todo!() time_frame: &TimeFrame,
+    ) -> UsdNewtype;
+
+    // Retrieve the freshest Ether price from database `ether_prices` table
+    async fn get_most_recent_price(&self) -> sqlx::Result<EthPrice>;
+
+    // Save value to `ether_prices` table
+    async fn store_price(&self, timestamp: &DateTime<Utc>, usd: f64);
+
+    // Retrieves the 24-hour average Ether price
+    #[allow(dead_code)]
+    async fn get_h24_average(&self) -> f64;
+
+    // Retrieve Ether price from the `eth_prices` table for 24 hours prior to the current timestamp.
+    async fn get_price_h24_ago(&self, duration: &Duration) -> Option<EthPrice>;
+
+    // Retrieve latest minutes ether price
+    async fn get_eth_price_by_minute(
+        &self,
+        minute: DateTime<Utc>,
+    ) -> Option<f64>;
+
+    // Retrieve closet(timestamp)'s ether price via Block
+    async fn get_closest_price_by_block(
+        &self,
+        // todo!(),  block: &ExecutionNodeBlock,
+    ) -> Result<f64, GetEthPriceError>;
+
+    // Retrieve ether price via Block
+    async fn get_eth_price_by_block(
+        &self,
+        // todo!(),  block: &ExecutionNodeBlock,
+    ) -> Result<f64, GetEthPriceError>;
+}
+
+#[async_trait]
+impl EthPriceStore for EthPriceStorePostgres {
+    async fn average_from_time_range(
+        &self,
+        start_timestamp: DateTime<Utc>,
+        end_timestamp: DateTime<Utc>,
+    ) -> UsdNewtype {
+        UsdNewtype(0.0)
+    }
+
+    /**
+     * To make compiler happy with this sqlx::query_as!(...), we need to exeucte commands below:
+     * # this install sql-cli
+     * cargo install sqlx-cli --no-default-features --features postgres
+     *
+     * # this add a migrate file on local
+     * cargo sqlx migrate add_eth_prices_table
+     *
+     * # add eth_prices sql commands to generated migration file: migrations **_add_eth_prices_table
+     * -- Add migration script here
+     * CREATE TABLE IF NOT EXISTS eth_prices (
+     * timestamp timestamptz PRIMARY KEY,
+     * ethusd float8 NOT NULL
+     * )
+     *
+     * # this execute migrate file's inner sql command on the deaultdb database
+     * sqlx migrate run --database-url postgres://admin:admin@localhost:5432/defaultdb
+     *
+     */
+    async fn get_most_recent_price(&self) -> sqlx::Result<EthPrice> {
+        sqlx::query_as!(
+            EthPrice,
+            "
+            SELECT 
+                timestamp, ethusd as usd
+            FROM
+                eth_prices
+            ORDER BY timestamp DESC
+            LIMIT 1
+            ",
+        )
+        .fetch_one(&self.db_pool)
+        .await
+    }
+
+    async fn store_price(&self, timestamp: &DateTime<Utc>, usd: f64) {
+        sqlx::query!(
+            "
+            INSERT INTO 
+                eth_prices (timestamp, ethusd)
+            VALUES($1, $2)
+            ON CONFLICT (timestamp) DO UPDATE SET
+                ethusd = excluded.ethusd 
+            ",
+            timestamp,
+            usd
+        )
+        .execute(&self.db_pool)
+        .await
+        .unwrap();
+    }
+
+    #[allow(dead_code)]
+    async fn get_h24_average(&self) -> f64 {
+        sqlx::query!(
+            r#"
+        SELECT 
+            AVG(ethusd) as "average!"
+        FROM
+            eth_prices
+        WHERE timestamp >= NOW() - '24 hours'::INTERVAL
+        "#,
+        )
+        .fetch_one(&self.db_pool)
+        .await
+        .unwrap()
+        .average
+    }
+
+    // query ether price value from `eth_prices` which with current timestamp closest to
+    // min(current timestamp - 24 hourse before)
+    async fn get_price_h24_ago(
+        &self,
+        age_limit: &Duration,
+    ) -> Option<EthPrice> {
+        sqlx::query_as!(
+            EthPrice,
+            "
+            WITH 
+              eth_price_distances AS (
+              SELECT 
+                ethusd,
+                timestamp,
+                ABS (
+                  EXTRACT(
+                      epoch
+                      FROM
+                        (timestamp - (NOW() - '24 hours':: INTERVAL))
+                  )
+                ) AS distance_seconds
+                FROM 
+                  eth_prices
+                ORDER BY
+                  distance_seconds ASC
+            )
+            SELECT ethusd as usd, timestamp
+            FROM eth_price_distances
+            WHERE distance_seconds <= $1
+            LIMIT 1
+            ",
+            age_limit.num_seconds() as i32
+        )
+        .fetch_optional(&self.db_pool)
+        .await
+        .unwrap()
+    }
+
+    async fn get_eth_price_by_minute(
+        &self,
+        timestamp: DateTime<Utc>,
+    ) -> Option<f64> {
+        sqlx::query!(
+            r#"
+            SELECT ethusd
+            FROM eth_prices
+            WHERE timestamp = $1
+            "#,
+            timestamp
+        )
+        .fetch_optional(&self.db_pool)
+        .await
+        .unwrap()
+        .map(|row| row.ethusd)
+    }
+
+    // -- todo!() --
+    async fn average_from_block_plus_time_range(
+        &self,
+        // todo!() block: &ExecuteNodeBlock,
+        // todo!() time_frame: &TimeFrame
+    ) -> UsdNewtype {
+        UsdNewtype(0.0)
+    }
+
+    async fn get_closest_price_by_block(
+        &self,
+        // todo!() block: &ExecutionNodeBlock,
+    ) -> Result<f64, GetEthPriceError> {
+        Ok(0.0)
+    }
+
+    async fn get_eth_price_by_block(
+        &self,
+        // todo!() block: &ExecutionNodeBlock,
+    ) -> Result<f64, GetEthPriceError> {
+        Ok(0.0)
+    }
+}

--- a/tutorial-5/src/eth_prices/store.rs
+++ b/tutorial-5/src/eth_prices/store.rs
@@ -267,6 +267,10 @@ mod tests {
             .await;
         let query_eth_price =
             eth_prices_store.get_most_recent_price().await.unwrap();
+        println!(
+            "query_eth_price: {:?}, target_value: {:?}",
+            query_eth_price, test_price
+        );
         assert_eq!(query_eth_price, test_price);
     }
 
@@ -293,6 +297,10 @@ mod tests {
 
         let eth_price_ret =
             eth_price_store.get_most_recent_price().await.unwrap();
+        println!(
+            "eth_price_ret {:?}, target_value: {:?}",
+            eth_price_ret, test_price_2
+        );
         assert_eq!(eth_price_ret, test_price_2);
     }
 

--- a/tutorial-5/src/lib.rs
+++ b/tutorial-5/src/lib.rs
@@ -2,6 +2,7 @@ pub mod bybit;
 pub mod caching;
 pub mod db;
 pub mod env;
+pub mod eth_prices;
 pub mod health;
 pub mod key_value_store;
 pub mod mockservices;

--- a/tutorial-5/src/units/mod.rs
+++ b/tutorial-5/src/units/mod.rs
@@ -5,6 +5,7 @@ mod wei;
 
 pub use eth::EthNewType;
 pub use gwei::GWeiNewType;
+pub use usd::UsdNewtype;
 pub use wei::WeiNewType;
 
 // 1 ETH = 10 ^9 Gwei


### PR DESCRIPTION
In this commit, we begin to add codes for Ethereum price records. 

In previous commits, we have 
1. encapsulated the PostgreSQL DB's connection and basic database operation into classes. 
2. abstract the Ether price records which fetched from [Bybit](https://bybit-exchange.github.io/docs/v5/market/kline) API Endpoints into different Eth* structs, and name the database table which stores the ether price value as `eth_prices`. 
  
```sql 
CREATE TABLE IF NOT EXISTS eth_prices (
	timestamp timestamptz PRIMARY KEY,
	ethusd float8 NOT NULL
)

```

In this commit, we focus on implementing the business logic for ether price abstraction structs, including query, update, and delete operations within the service layer.